### PR TITLE
Add payment cards and old security options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ public function registerBundles()
 
 Go to the payment methods in your admin panel. Now you should be able to add new payment method for System Pay gateway.
 
+The **Payment methods** option in the gateway is optional. From the Systempay documentation:
+* If the list contains only one type of card, the data entry page for this payment method will be presented directly,
+* otherwise the payment method selection page will be presented,
+* if this parameter is empty (recommended) then all eligible payment methods (currency, technical constraints, etc.)
+associated with the store will be offered.
+
 ## Testing
 ```bash
 $ wget http://getcomposer.org/composer.phar

--- a/src/Action/CaptureAction.php
+++ b/src/Action/CaptureAction.php
@@ -115,6 +115,7 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface
 
         $environment = $this->systemPayBridge->getEnvironment();
         $merchantId = $this->systemPayBridge->getMerchantId();
+        $paymentCards = $this->systemPayBridge->getPaymentCards();
 
         $automaticResponseUrl = $notifyToken->getTargetUrl();
         $currencyCode = $payment->getCurrencyCode();
@@ -132,6 +133,7 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface
         $simplePayment = new SimplePayment(
             $systemPay,
             $merchantId,
+            $paymentCards,
             $environment,
             $amount,
             $targetUrl,

--- a/src/Action/CaptureAction.php
+++ b/src/Action/CaptureAction.php
@@ -116,6 +116,7 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface
         $environment = $this->systemPayBridge->getEnvironment();
         $merchantId = $this->systemPayBridge->getMerchantId();
         $paymentCards = $this->systemPayBridge->getPaymentCards();
+        $useOldSecurity = $this->systemPayBridge->useOldSecurity();
 
         $automaticResponseUrl = $notifyToken->getTargetUrl();
         $currencyCode = $payment->getCurrencyCode();
@@ -135,6 +136,7 @@ final class CaptureAction implements ActionInterface, ApiAwareInterface
             $merchantId,
             $paymentCards,
             $environment,
+            $useOldSecurity,
             $amount,
             $targetUrl,
             $currencyCode,

--- a/src/Bridge/SystemPayBridge.php
+++ b/src/Bridge/SystemPayBridge.php
@@ -38,6 +38,11 @@ final class SystemPayBridge implements SystemPayBridgeInterface
     private $environment;
 
     /**
+     * @var string
+     */
+    private $paymentCards;
+
+    /**
      * @param RequestStack $requestStack
      */
     public function __construct(RequestStack $requestStack)
@@ -133,5 +138,21 @@ final class SystemPayBridge implements SystemPayBridgeInterface
     public function setEnvironment($environment)
     {
         $this->environment = $environment;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getPaymentCards()
+    {
+        return $this->paymentCards;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setPaymentCards($paymentCards)
+    {
+        $this->paymentCards = $paymentCards;
     }
 }

--- a/src/Bridge/SystemPayBridge.php
+++ b/src/Bridge/SystemPayBridge.php
@@ -43,6 +43,11 @@ final class SystemPayBridge implements SystemPayBridgeInterface
     private $paymentCards;
 
     /**
+     * @var bool
+     */
+    private $useOldSecurity;
+
+    /**
      * @param RequestStack $requestStack
      */
     public function __construct(RequestStack $requestStack)
@@ -154,5 +159,21 @@ final class SystemPayBridge implements SystemPayBridgeInterface
     public function setPaymentCards($paymentCards)
     {
         $this->paymentCards = $paymentCards;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function useOldSecurity()
+    {
+        return $this->useOldSecurity;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setUseOldSecurity($useOldSecurity)
+    {
+        $this->useOldSecurity = $useOldSecurity;
     }
 }

--- a/src/Bridge/SystemPayBridgeInterface.php
+++ b/src/Bridge/SystemPayBridgeInterface.php
@@ -10,7 +10,7 @@
 
 namespace Waaz\SystemPayPlugin\Bridge;
 
-use Waaz\SystemPayPlugin\Legacy\SimplePay;
+use Waaz\SystemPayPlugin\Legacy\SystemPay;
 
 /**
  * @author Ibes Mongabure <developpement@studiowaaz.com>
@@ -20,7 +20,7 @@ interface SystemPayBridgeInterface
     /**
      * @param string $secretKey
      *
-     * @return SimplePay
+     * @return SystemPay
      */
     public function createSystemPay($secretKey);
 
@@ -63,4 +63,14 @@ interface SystemPayBridgeInterface
      * @param string $environment
      */
     public function setEnvironment($environment);
+
+    /**
+     * @return string
+     */
+    public function getPaymentCards();
+
+    /**
+     * @param string $paymentCards
+     */
+    public function setPaymentCards($paymentCards);
 }

--- a/src/Bridge/SystemPayBridgeInterface.php
+++ b/src/Bridge/SystemPayBridgeInterface.php
@@ -73,4 +73,14 @@ interface SystemPayBridgeInterface
      * @param string $paymentCards
      */
     public function setPaymentCards($paymentCards);
+
+    /**
+     * @return bool
+     */
+    public function useOldSecurity();
+
+    /**
+     * @param bool $useOldSecurity
+     */
+    public function setUseOldSecurity($useOldSecurity);
 }

--- a/src/Form/Type/SystemPayGatewayConfigurationType.php
+++ b/src/Form/Type/SystemPayGatewayConfigurationType.php
@@ -11,7 +11,9 @@
 namespace Waaz\SystemPayPlugin\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\RadioType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormEvent;
@@ -57,6 +59,10 @@ final class SystemPayGatewayConfigurationType extends AbstractType
             ->add('payment_cards', TextType::class, [
                 'required' => false,
                 'label' => 'waaz.system_pay.payment_cards',
+            ])
+            ->add('use_old_security', CheckboxType::class, [
+                'required' => false,
+                'label' => 'waaz.system_pay.use_old_security',
             ])
             ->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event) {
                 $data = $event->getData();

--- a/src/Form/Type/SystemPayGatewayConfigurationType.php
+++ b/src/Form/Type/SystemPayGatewayConfigurationType.php
@@ -10,7 +10,6 @@
 
 namespace Waaz\SystemPayPlugin\Form\Type;
 
-use Waaz\SystemPayPlugin\Legacy\Mercanet;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -55,7 +54,7 @@ final class SystemPayGatewayConfigurationType extends AbstractType
                     ])
                 ],
             ])
-            ->addEventListener(FormEvents::PRE_SET_DATA, function (FormEvent $event) {
+            ->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event) {
                 $data = $event->getData();
                 $data['payum.http_client'] = '@waaz.system_pay.bridge.system_pay_bridge';
                 $event->setData($data);

--- a/src/Form/Type/SystemPayGatewayConfigurationType.php
+++ b/src/Form/Type/SystemPayGatewayConfigurationType.php
@@ -54,6 +54,10 @@ final class SystemPayGatewayConfigurationType extends AbstractType
                     ])
                 ],
             ])
+            ->add('payment_cards', TextType::class, [
+                'required' => false,
+                'label' => 'waaz.system_pay.payment_cards',
+            ])
             ->addEventListener(FormEvents::PRE_SET_DATA, static function (FormEvent $event) {
                 $data = $event->getData();
                 $data['payum.http_client'] = '@waaz.system_pay.bridge.system_pay_bridge';

--- a/src/Legacy/SimplePayment.php
+++ b/src/Legacy/SimplePayment.php
@@ -35,6 +35,11 @@ final class SimplePayment
     /**
      * @var string
      */
+    private $paymentCards;
+
+    /**
+     * @var string
+     */
     private $amount;
 
     /**
@@ -65,16 +70,19 @@ final class SimplePayment
     /**
      * @param SystemPay $systemPay
      * @param $merchantId
+     * @param $paymentCards
      * @param $environment
      * @param $amount
      * @param $targetUrl
      * @param $currency
      * @param $transactionReference
      * @param $automaticResponseUrl
+     * @param $cancelUrl
      */
     public function __construct(
         SystemPay $systemPay,
         $merchantId,
+        $paymentCards,
         $environment,
         $amount,
         $targetUrl,
@@ -89,6 +97,7 @@ final class SimplePayment
         $this->systemPay = $systemPay;
         $this->environment = $environment;
         $this->merchantId = $merchantId;
+        $this->paymentCards = $paymentCards;
         $this->amount = $amount;
         $this->currency = $currency;
         $this->targetUrl = $targetUrl;
@@ -99,6 +108,7 @@ final class SimplePayment
     {
         $this->systemPay->setFields([
           'site_id' => $this->merchantId,
+          'payment_cards' => $this->paymentCards,
           'ctx_mode' => $this->environment,
           'amount' => $this->amount,
           'currency' => CurrencyNumber::getByCode($this->currency),

--- a/src/Legacy/SimplePayment.php
+++ b/src/Legacy/SimplePayment.php
@@ -28,6 +28,11 @@ final class SimplePayment
     private $environment;
 
     /**
+     * @var bool
+     */
+    private $useOldSecurity;
+
+    /**
      * @var string
      */
     private $merchantId;
@@ -72,6 +77,7 @@ final class SimplePayment
      * @param $merchantId
      * @param $paymentCards
      * @param $environment
+     * @param $useOldSecurity
      * @param $amount
      * @param $targetUrl
      * @param $currency
@@ -84,6 +90,7 @@ final class SimplePayment
         $merchantId,
         $paymentCards,
         $environment,
+        $useOldSecurity,
         $amount,
         $targetUrl,
         $currency,
@@ -96,6 +103,7 @@ final class SimplePayment
         $this->transactionReference = $transactionReference;
         $this->systemPay = $systemPay;
         $this->environment = $environment;
+        $this->useOldSecurity = $useOldSecurity;
         $this->merchantId = $merchantId;
         $this->paymentCards = $paymentCards;
         $this->amount = $amount;
@@ -106,6 +114,7 @@ final class SimplePayment
 
     public function execute()
     {
+        $this->systemPay->setUseOldSecurity($this->useOldSecurity);
         $this->systemPay->setFields([
           'site_id' => $this->merchantId,
           'payment_cards' => $this->paymentCards,

--- a/src/Legacy/SystemPay.php
+++ b/src/Legacy/SystemPay.php
@@ -19,13 +19,13 @@ class SystemPay
         'action_mode' => null,
         'ctx_mode' => null,
         'page_action' => null,
+        'payment_cards' => null,
         'payment_config' => null,
         'site_id' => null,
         'version' => 'V2',
         'redirect_success_message' => null,
         'redirect_error_message' => null,
         'url_return' => null,
-        'payment_cards' => null,
     );
 
     /**

--- a/src/Legacy/SystemPay.php
+++ b/src/Legacy/SystemPay.php
@@ -33,6 +33,11 @@ class SystemPay
      */
     private $key;
 
+    /**
+     * @var bool
+     */
+    private $useOldSecurity;
+
     public function __construct($key)
     {
         $this->key = $key;
@@ -52,6 +57,14 @@ class SystemPay
             if (empty($this->mandatoryFields[$field]) || $field == 'payment_config')
                 $this->mandatoryFields[$field] = $value;
         return $this;
+    }
+
+    /**
+     * @param bool $useOldSecurity
+     */
+    public function setUseOldSecurity($useOldSecurity)
+    {
+        $this->useOldSecurity = $useOldSecurity;
     }
 
     /**
@@ -96,7 +109,13 @@ class SystemPay
         foreach ($fields as $field => $value)
                 $contenu_signature .= $value."+";
         $contenu_signature .= $this->key;
-        $signature = base64_encode(hash_hmac('sha256', $contenu_signature, $this->key, true));
+
+        if ($this->useOldSecurity) {
+            $signature = sha1(utf8_encode($contenu_signature));
+        } else {
+            $signature = base64_encode(hash_hmac('sha256', utf8_encode($contenu_signature), $this->key, true));
+        }
+
         return $signature;
     }
 

--- a/src/Legacy/SystemPay.php
+++ b/src/Legacy/SystemPay.php
@@ -25,6 +25,7 @@ class SystemPay
         'redirect_success_message' => null,
         'redirect_error_message' => null,
         'url_return' => null,
+        'payment_cards' => null,
     );
 
     /**

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -8,3 +8,4 @@ waaz:
         production: Production
         test: Test
         simulation: Simulation
+        payment_cards: Payment methods (Empty => tous les moyens de paiement éligibles)

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -9,3 +9,4 @@ waaz:
         test: Test
         simulation: Simulation
         payment_cards: Payment methods (Empty => tous les moyens de paiement éligibles)
+        use_old_security: Use obsolete SHA-1 security for signature calcul

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -9,3 +9,4 @@ waaz:
         test: Test
         simulation: Simulation
         payment_cards: Moyens de paiement (Vide => tous les moyens de paiement éligibles)
+        use_old_security: Utilisez la sécurité SHA-1 obsolète pour le calcul de signature

--- a/src/Resources/translations/messages.fr.yml
+++ b/src/Resources/translations/messages.fr.yml
@@ -8,3 +8,4 @@ waaz:
         production: Production
         test: Test
         simulation: Simulation
+        payment_cards: Moyens de paiement (Vide => tous les moyens de paiement éligibles)

--- a/src/SystemPayGatewayFactory.php
+++ b/src/SystemPayGatewayFactory.php
@@ -39,7 +39,8 @@ final class SystemPayGatewayFactory extends GatewayFactory
                 'environment' => '',
                 'secure_key' => '',
                 'merchant_id' => '',
-                'payment_cards' => ''
+                'payment_cards' => '',
+                'use_old_security' => false,
             ];
 
             $config->defaults($config['payum.default_options']);
@@ -55,6 +56,10 @@ final class SystemPayGatewayFactory extends GatewayFactory
                 $systemPayBridge->setMerchantId($config['merchant_id']);
                 $systemPayBridge->setPaymentCards($config['payment_cards']);
                 $systemPayBridge->setEnvironment($config['environment']);
+
+                if (isset($config['use_old_security'])) {
+                    $systemPayBridge->setUseOldSecurity($config['use_old_security']);
+                }
 
                 return $systemPayBridge;
             };

--- a/src/SystemPayGatewayFactory.php
+++ b/src/SystemPayGatewayFactory.php
@@ -38,13 +38,14 @@ final class SystemPayGatewayFactory extends GatewayFactory
             $config['payum.default_options'] = [
                 'environment' => '',
                 'secure_key' => '',
-                'merchant_id' => ''
+                'merchant_id' => '',
+                'payment_cards' => ''
             ];
 
             $config->defaults($config['payum.default_options']);
             $config['payum.required_options'] = ['secret_key', 'environment', 'merchant_id'];
 
-            $config['payum.api'] = function (ArrayObject $config) {
+            $config['payum.api'] = static function (ArrayObject $config) {
                 $config->validateNotEmpty($config['payum.required_options']);
 
                 /** @var SystemPayBridgeInterface $systemPayBridge */
@@ -52,6 +53,7 @@ final class SystemPayGatewayFactory extends GatewayFactory
 
                 $systemPayBridge->setSecretKey($config['secret_key']);
                 $systemPayBridge->setMerchantId($config['merchant_id']);
+                $systemPayBridge->setPaymentCards($config['payment_cards']);
                 $systemPayBridge->setEnvironment($config['environment']);
 
                 return $systemPayBridge;


### PR DESCRIPTION
Hi,

This PR add an option to set the [payment_cards](https://paiement.systempay.fr/doc/en-EN/form-payment/standard-payment/vads-payment-cards.html) option. It allow us to display two payments methods: one for credit cards and one for e-check for example.

A second option was added to allow usage of the old security calcul of the signature with the SHA-1 algorithm instead of SHA-256.

Thank you for your work!